### PR TITLE
docs: remove getting-started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,3 @@ ColoredPrint.log(
 **Result:**
 
 ![image](https://user-images.githubusercontent.com/16373553/112857975-cc72ea80-9087-11eb-9bc5-9073827a68c9.png)
-
-## Getting Started
-
-This project is a starting point for a Dart
-[package](https://flutter.dev/developing-packages/),
-a library module containing code that can be shared easily across
-multiple Flutter or Dart projects.
-
-For help getting started with Flutter, view our 
-[online documentation](https://flutter.dev/docs), which offers tutorials, 
-samples, guidance on mobile development, and a full API reference.


### PR DESCRIPTION
Removes default dart-package leftovers.